### PR TITLE
chore: update Dioxus serve port to resolve Acitx communication issue

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -16,7 +16,7 @@ workspace = false
 cwd = "./front"
 install_crate = "dioxus-cli"
 command = "dioxus"
-args = ["serve"]
+args = ["serve", "--port", "8000"]
 
 [tasks.front-build]
 workspace = false

--- a/docs/src/frontend/03_02_app_startup.md
+++ b/docs/src/frontend/03_02_app_startup.md
@@ -83,7 +83,7 @@ npx tailwindcss -i ./input.css -o ./public/tailwind.css --watch
 2. **Launch Dioxus in serve mode**: Run the following command to start the Dioxus development server. This server will monitor your source code for changes, recompile your application as necessary, and serve the resulting web application.
 
 ```bash
-dioxus serve
+dioxus serve --port 8000
 ```
 
 Now, your development environment is up and running. Changes you make to your source code will automatically be reflected in the served application, thanks to the watching capabilities of both the Tailwind compiler and the Dioxus server. You're now ready to start building your Dioxus application!

--- a/front/README.md
+++ b/front/README.md
@@ -138,10 +138,10 @@ npx tailwindcss -i ./input.css -o ./public/tailwind.css --watch
 - Run the following command in the root of the project to start the dioxus dev server:
 
 ```bash
-dioxus serve
+dioxus serve --port 8000
 ```
 
-- Open the browser to http://localhost:8080
+- Open the browser to http://localhost:8000
 
 # Usefull resources
 - [Movie posters](https://www.movieposters.com/)


### PR DESCRIPTION
Thank you for creating great tutorial.

In the course of the tutorial, there was one part that did not work, so I created pull request.

When starting with `dioxus serve`, I got a `404: NOT FOUND` error when trying to get films via API communication.
The reason is that dioxus is started on `localhost:8080`, while shuttle is started on `localhost:8000`. 
When I checked the dioxus default port, it says `8080`, so unless I specify `8000` here, I will not be able to get the data correctly.
<img width="716" alt="Screen Shot 2023-07-20 at 17 17 37" src="https://github.com/BcnRust/devbcn-workshop/assets/56007015/0abae6ac-d042-4099-a895-94e5c18728be">
Therefore, the `dioxus serve` command has been modified to specify `--port 8000`. 