### PR TITLE
docs: fix a typo in 2.11

### DIFF
--- a/docs/src/backend/11_watch_mode.md
+++ b/docs/src/backend/11_watch_mode.md
@@ -1,6 +1,6 @@
 # Watch Mode
 
-You may we thinking that it would be nice to have a way to **automatically restart the backend when you make changes to the code**. 
+You may be thinking that it would be nice to have a way to **automatically restart the backend when you make changes to the code**. 
 
 Well, you're in luck! Enter [cargo-watch](https://github.com/watchexec/cargo-watch).
 


### PR DESCRIPTION
Thanks for the great workshop!

I just found there is a minor typo in `2.11. Watch Mode`.
Sorry if it's not a typo.